### PR TITLE
Fix typo `build-and-push-mage` -> `build-and-push-image`

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -36,7 +36,7 @@ jobs:
   make-release:
     name: 'Update dependents'
     runs-on: ubuntu-latest
-    needs: build-and-push-mage
+    needs: build-and-push-image
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v3


### PR DESCRIPTION
Fixes a small typo in `master-push.yml`