### PR TITLE
Temporarily comment out most of Dockerfile

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -1,4 +1,4 @@
-name: 'Test PR'
+name: 'Push to Master'
 on:
   push:
     branches:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,37 +2,37 @@ ARG BASE_OS
 ARG BASE_DISTRO
 FROM ${BASE_OS}:${BASE_DISTRO}
 
-RUN    apt-get update        \
-    && apt-get upgrade --yes \
-    && apt-get install --yes \
-       autoconf              \
-       automake              \
-       autotools-dev         \
-       curl                  \
-       python3               \
-       libmpc-dev            \
-       libmpfr-dev           \
-       libgmp-dev            \
-       gawk                  \
-       build-essential       \
-       bison                 \
-       flex                  \
-       texinfo               \
-       gperf                 \
-       libtool               \
-       patchutils            \
-       bc                    \
-       zlib1g-dev            \
-       libexpat-dev          \
-       git
+# RUN    apt-get update        \
+#     && apt-get upgrade --yes \
+#     && apt-get install --yes \
+#        autoconf              \
+#        automake              \
+#        autotools-dev         \
+#        curl                  \
+#        python3               \
+#        libmpc-dev            \
+#        libmpfr-dev           \
+#        libgmp-dev            \
+#        gawk                  \
+#        build-essential       \
+#        bison                 \
+#        flex                  \
+#        texinfo               \
+#        gperf                 \
+#        libtool               \
+#        patchutils            \
+#        bc                    \
+#        zlib1g-dev            \
+#        libexpat-dev          \
+#        git
 
-ENV RISCV=/opt/riscv
-ENV PATH=$PATH:$RISCV/bin
+# ENV RISCV=/opt/riscv
+# ENV PATH=$PATH:$RISCV/bin
 
 ARG TOOLCHAIN_VERSION=2024.04.12
-RUN    git clone --recursive https://github.com/riscv/riscv-gnu-toolchain -b ${TOOLCHAIN_VERSION} \
-    && cd riscv-gnu-toolchain                                                                     \
-    && ./configure --prefix=$RISCV --enable-multilib                                              \
-    && make                                                                                       \
-    && cd ..                                                                                      \
-    && rm -rf riscv-gnu-toolchain
+# RUN    git clone --recursive https://github.com/riscv/riscv-gnu-toolchain -b ${TOOLCHAIN_VERSION} \
+#     && cd riscv-gnu-toolchain                                                                     \
+#     && ./configure --prefix=$RISCV --enable-multilib                                              \
+#     && make                                                                                       \
+#     && cd ..                                                                                      \
+#     && rm -rf riscv-gnu-toolchain


### PR DESCRIPTION
This PR temporarily removes the actual `riscv-gnu-toolchain` install from the `Dockerfile` so that we can debug the master push workflow without waiting for a 2 hour build.